### PR TITLE
[funexpected.export] remove extra files from exported pack

### DIFF
--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -136,6 +136,9 @@ public:
 	void set_script_encryption_key(const String &p_key);
 	String get_script_encryption_key() const;
 
+	bool get_export_non_resource_files() const;
+	void set_export_non_resource_files(bool mode);
+
 	const List<PropertyInfo> &get_properties() const { return properties; }
 
 	EditorExportPreset();


### PR DESCRIPTION
Чтобы не экспортировать лишние файлы в пакетах миссий:
1. добавить в preset need_common_application_files=false:
```
script_export_mode=1
script_encryption_key=""
need_common_application_files=false
```

2. Добавить тэг export_module - он влияет на EditorExportPlugin в движке (в ветке миссий!)
`custom_features="prod,translations,export_module"`

