### PR TITLE
Wrapping 3.3+374 commits into a threaded libmode (to embed under React)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# Funexpected Godot — custom engine fork
+
+Funexpected's proprietary fork of Godot 3.3+. C++ engine used by Funexpected Math (the private `math` repo) on iOS, Android, and Web.
+
+This repo only contains the engine. The game client, tooling, backend and scripts live in the private sister repo `math`.
+
+## What's customized vs upstream Godot 3.3
+
+| Area | Customization |
+|------|---------------|
+| `modules/flash/` | Adobe Animate playback (`.zfl` import, `FlashPlayer` Node2D). Separate public repo: [funexpected/godot-flash-module](https://github.com/funexpected/godot-flash-module). See its `CLAUDE.md`. |
+| `modules/spine/` | Spine 2D skeletal animation (multi-version runtime: 3.6–4.1). Separate public repo: [funexpected/godot-spine-module](https://github.com/funexpected/godot-spine-module). See its `CLAUDE.md`. |
+| `modules/fnxext/` | Funexpected extensions: `Future` (async), `OnnxEngine` (ML), `MeshLine2D`, visibility culling, canvas-layers editor plugin. In-tree — see [modules/fnxext/CLAUDE.md](modules/fnxext/CLAUDE.md). |
+| `platform/iphone/` | Orientation handling fixes, tablet horizontal-start, windowed-mode fix (`[funexpected]`, `[funexpected.mobile]` commits). |
+| `platform/android/` | NDK 27 / SDK 35 support, build fixes (`[funexpected.android]` commits). |
+| `platform/osx/` | Build fixes for newer macOS (`[funexpected]` commits). |
+| Debugger | `ScriptDebuggerStack` (`[fnx]` commits) — default debugger for IDE integration. |
+
+## Repo layout
+
+Standard Godot 3.3 tree: `core/ editor/ drivers/ main/ modules/ platform/ scene/ servers/ thirdparty/ doc/`. SCons build system (`SConstruct`). All Funexpected code is confined to the three custom modules plus platform-specific patches.
+
+## Build
+
+Standard Godot SCons. Examples:
+
+```bash
+# iOS release template
+scons platform=iphone tools=no target=release
+
+# Android debug template, with Spine 3.8 runtime
+scons platform=android target=debug spine_runtime_3_8=yes
+
+# Editor for Linux
+scons platform=x11 tools=yes target=debug
+```
+
+Module-specific build flags (e.g. Spine runtime versions) are documented in each module's `CLAUDE.md`.
+
+## Branches
+
+- `master` — mirrors upstream Godot 3.3 branch; Funexpected fixes are cherry-picked on top.
+- `react` — current working branch used by the game.
+- Feature branches — short-lived; merged via PR with the commit conventions below.
+
+## Commit conventions
+
+Format: `[tag] lowercase description (#PR_NUMBER)`.
+
+Tags seen in this repo:
+- `[funexpected]` — generic fork maintenance (build, platform fixes).
+- `[funexpected.mobile]` — iOS/Android behavior shared across mobile.
+- `[funexpected.android]` — Android-specific (NDK/SDK, manifests).
+- `[funexpected.flash]` — `modules/flash` changes.
+- `[fnx]` — `modules/fnxext` (ONNX, Future, debugger).
+
+Match the style used in the sister `math` repo's `CLAUDE.md`.
+
+## Related repos
+
+- `math` (private) — game client, backend, CI, tooling. Consumes this engine via its `engine/` submodule.
+- `futuramath` (private) — related project.
+- [funexpected/godot-flash-module](https://github.com/funexpected/godot-flash-module) — the `modules/flash` submodule.
+- [funexpected/godot-spine-module](https://github.com/funexpected/godot-spine-module) — the `modules/spine` submodule.
+
+## Upstream
+
+Based on [Godot 3.3.x](https://github.com/godotengine/godot/tree/3.3). Refer to upstream docs for non-custom subsystems (servers, scene tree, GDScript 1.x).

--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -90,6 +90,16 @@ public:
 	// get the ID of the main thread
 	_FORCE_INLINE_ static ID get_main_id() { return main_thread_id; }
 
+	// Reassign main_thread_id to the calling thread. By default it's pinned to
+	// whichever thread first loaded the binary (the platform main thread for an
+	// iOS framework). Library/embedded hosts that drive Main::iteration from a
+	// worker thread call this from that worker, before Main::setup, so subsequent
+	// `is_main_thread`-style checks across the engine treat the worker as main.
+	// Main::setup2 also accepts a tid override (used by Android), but doing it
+	// up-front means register_core_types and project parsing also see the right
+	// thread identity.
+	_FORCE_INLINE_ static void make_main_thread() { main_thread_id = get_caller_id(); }
+
 	static Error set_name(const String &p_name);
 
 	void start(Thread::Callback p_callback, void *p_user, const Settings &p_settings = Settings());
@@ -104,6 +114,7 @@ public:
 	_FORCE_INLINE_ static ID get_caller_id() { return 0; }
 	// get the ID of the main thread
 	_FORCE_INLINE_ static ID get_main_id() { return 0; }
+	_FORCE_INLINE_ static void make_main_thread() {}
 
 	static Error set_name(const String &p_name) { return ERR_UNAVAILABLE; }
 

--- a/modules/fnxext/CLAUDE.md
+++ b/modules/fnxext/CLAUDE.md
@@ -1,0 +1,30 @@
+# modules/fnxext — Funexpected engine extensions
+
+Grab-bag of Funexpected-specific additions to Godot 3.3: async primitives, ML inference, 2D rendering helpers, and an editor plugin. Not a single coherent subsystem — each class solves a discrete need from the game (private `math` repo).
+
+## Registered classes
+
+Registration in [register_types.cpp:23-37](register_types.cpp#L23-L37).
+
+| Class | Extends | Purpose |
+|-------|---------|---------|
+| [`Future`](future.h) | Reference | Promise/future async primitive for chaining signals, timers, and threads. Methods: `then`, `wait`, `finally`, `retain`, `await`, static `start`, `yield`. See [FUTURE.md](FUTURE.md) for usage examples. |
+| [`OnnxEngine`](onnx_engine.h) | Reference | ONNX model inference. Load a `.onnx` file, set input/output layers, call `run()`. Bundled runtime under [onnx_engine/](onnx_engine/). |
+| [`MeshLine2D`](mesh_line_2d.h) | Node2D | 2D polyline primitive with curve support, gradient, and optional texturing. |
+| [`StyleBoxBorderedTexture`](stylebox_bordered_texture.h) | StyleBoxTexture | StyleBox variant with configurable borders on top of a texture. |
+| [`VisibilityController2D`](visibility_controller_2d.h) | Node2D | Viewport-based visibility culling — activates/deactivates grouped nodes when entering/leaving the screen. |
+| [`ZipTool`](zip_tool.h) | Reference | Archive listing utility (read-only inspection of `.zip` contents). |
+
+## Editor plugin
+
+`CanvasLayersEditorPlugin` ([canvas_layers_editor_plugin.h](canvas_layers_editor_plugin.h)) is registered when the engine is built with `TOOLS_ENABLED` ([register_types.cpp:17-21](register_types.cpp#L17-L21)). Adds a UI for selecting and toggling canvas-layer visibility inside the scene editor.
+
+## Build
+
+Standard module — no extra SCons flags. `SCsub` compiles every `.cpp` in the module directory plus the ONNX runtime.
+
+## Notes
+
+- `Future` is used throughout the math game's GDScript for async flows (resource loading, animation sequencing) as an alternative to `yield` chains. Prefer reading [FUTURE.md](FUTURE.md) before touching its C++.
+- `OnnxEngine` is consumed by the game for on-device inference (e.g. handwriting / character recognition).
+- Nothing in this module is visible to upstream Godot — all classes are Funexpected-only.

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -1,7 +1,17 @@
 import os
+import re
 import sys
 import platform
-from distutils.version import LooseVersion
+
+
+def _version_ge(a, b):
+    # Replacement for distutils.version.LooseVersion comparison.
+    # distutils was removed in Python 3.12; this keeps the build working on
+    # newer Python without adding a packaging/ dependency.
+    def _tuple(v):
+        return tuple(int(p) for p in re.findall(r"\d+", v))
+
+    return _tuple(a) >= _tuple(b)
 
 
 def is_active():
@@ -316,7 +326,7 @@ def configure(env):
     # Link flags
 
     ndk_version = get_env_ndk_version(env["ANDROID_NDK_ROOT"])
-    if ndk_version != None and LooseVersion(ndk_version) >= LooseVersion("17.1.4828580"):
+    if ndk_version != None and _version_ge(ndk_version, "17.1.4828580"):
         env.Append(LINKFLAGS=["-Wl,--exclude-libs,libgcc.a", "-Wl,--exclude-libs,libatomic.a", "-nostdlib++"])
     # Note: NDK 27+ doesn't need libandroid_support.a - it's handled by the unified toolchain
     env.Append(LINKFLAGS=["-shared", "--sysroot=" + lib_sysroot, "-Wl,--warn-shared-textrel"])

--- a/platform/iphone/SCsub
+++ b/platform/iphone/SCsub
@@ -18,6 +18,7 @@ iphone_lib = [
     "device_metrics.m",
     "keyboard_input_view.mm",
     "native_video_view.m",
+    "library_entry.mm",
 ]
 
 env_ios = env.Clone()

--- a/platform/iphone/SCsub
+++ b/platform/iphone/SCsub
@@ -19,6 +19,7 @@ iphone_lib = [
     "keyboard_input_view.mm",
     "native_video_view.m",
     "library_entry.mm",
+    "host_input_queue.mm",
 ]
 
 env_ios = env.Clone()

--- a/platform/iphone/app_delegate.h
+++ b/platform/iphone/app_delegate.h
@@ -37,4 +37,12 @@
 @property(strong, nonatomic) UIWindow *window;
 @property(strong, class, readonly, nonatomic) ViewController *viewController;
 
+#ifdef IOS_LIBRARY_MODE
+// In library mode the host owns UIApplicationMain, so didFinishLaunchingWithOptions
+// never runs and mainViewController stays nil. Host apps use this setter to register
+// the active ViewController so the rest of the engine (keyboard, orientation, video,
+// render start/stop in os_iphone.mm / ios.mm) can reach it via AppDelegate.viewController.
++ (void)setViewController:(ViewController *)viewController;
+#endif
+
 @end

--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -55,6 +55,12 @@ static ViewController *mainViewController = nil;
 	return mainViewController;
 }
 
+#ifdef IOS_LIBRARY_MODE
++ (void)setViewController:(ViewController *)viewController {
+	mainViewController = viewController;
+}
+#endif
+
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 	// Create a full-screen window
 	CGRect windowBounds = [[UIScreen mainScreen] bounds];

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -40,6 +40,11 @@ def get_opts():
             "Build as a library for host apps; omits UIApplicationMain entry so the host owns the app lifecycle",
             False,
         ),
+        BoolVariable(
+            "ios_simulator",
+            "Target the iOS Simulator runtime (arm64 for Apple Silicon hosts, x86_64 for Intel) instead of a physical device",
+            False,
+        ),
     ]
 
 
@@ -129,10 +134,16 @@ def configure(env):
             CCFLAGS='-fobjc-arc -arch armv7 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -fblocks -isysroot $IPHONESDK -fvisibility=hidden -mthumb "-DIBOutlet=__attribute__((iboutlet))" "-DIBOutletCollection(ClassName)=__attribute__((iboutletcollection(ClassName)))" "-DIBAction=void)__attribute__((ibaction)" -miphoneos-version-min=12.0 -MMD -MT dependencies'.split()
         )
     elif env["arch"] == "arm64":
-        detect_darwin_sdk_path("iphone", env)
-        env.Append(
-            CCFLAGS="-fobjc-arc -arch arm64 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -fblocks -fvisibility=hidden -MMD -MT dependencies -miphoneos-version-min=12.0 -isysroot $IPHONESDK".split()
-        )
+        if env["ios_simulator"]:
+            detect_darwin_sdk_path("iphonesimulator", env)
+            env.Append(
+                CCFLAGS="-fobjc-arc -arch arm64 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -fblocks -fvisibility=hidden -MMD -MT dependencies -mios-simulator-version-min=12.0 -isysroot $IPHONESDK".split()
+            )
+        else:
+            detect_darwin_sdk_path("iphone", env)
+            env.Append(
+                CCFLAGS="-fobjc-arc -arch arm64 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -fblocks -fvisibility=hidden -MMD -MT dependencies -miphoneos-version-min=12.0 -isysroot $IPHONESDK".split()
+            )
         env.Append(CPPDEFINES=["NEED_LONG_INT"])
         env.Append(CPPDEFINES=["LIBYUV_DISABLE_NEON"])
 
@@ -167,7 +178,10 @@ def configure(env):
     elif env["arch"] == "arm":
         env.Append(LINKFLAGS=["-arch", "armv7", "-Wl,-dead_strip", "-miphoneos-version-min=12.0"])
     if env["arch"] == "arm64":
-        env.Append(LINKFLAGS=["-arch", "arm64", "-Wl,-dead_strip", "-miphoneos-version-min=12.0"])
+        if env["ios_simulator"]:
+            env.Append(LINKFLAGS=["-arch", "arm64", "-Wl,-dead_strip", "-mios-simulator-version-min=12.0"])
+        else:
+            env.Append(LINKFLAGS=["-arch", "arm64", "-Wl,-dead_strip", "-miphoneos-version-min=12.0"])
 
     env.Append(
         LINKFLAGS=[
@@ -191,3 +205,8 @@ def configure(env):
 
     if env["ios_library"]:
         env.Append(CPPDEFINES=["IOS_LIBRARY_MODE"])
+
+    if env["ios_simulator"]:
+        # Distinguishes the simulator-flavored .a from the device-flavored one
+        # so both can coexist in bin/ and hosts can pick based on SDK.
+        env.extra_suffix = ".sim" + env.extra_suffix

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -35,6 +35,11 @@ def get_opts():
         ("IPHONESDK", "Path to the iPhone SDK", ""),
         BoolVariable("ios_exceptions", "Enable exceptions", False),
         ("ios_triple", "Triple for ios toolchain", ""),
+        BoolVariable(
+            "ios_library",
+            "Build as a library for host apps; omits UIApplicationMain entry so the host owns the app lifecycle",
+            False,
+        ),
     ]
 
 
@@ -183,3 +188,6 @@ def configure(env):
 
     env.Prepend(CPPPATH=["#platform/iphone"])
     env.Append(CPPDEFINES=["IPHONE_ENABLED", "UNIX_ENABLED", "GLES_ENABLED", "COREAUDIO_ENABLED"])
+
+    if env["ios_library"]:
+        env.Append(CPPDEFINES=["IOS_LIBRARY_MODE"])

--- a/platform/iphone/godot_iphone.mm
+++ b/platform/iphone/godot_iphone.mm
@@ -71,6 +71,9 @@ int add_cmdline(int p_argc, char **p_args) {
 }
 
 int iphone_main(int argc, char **argv, String data_dir) {
+	static int call_count = 0;
+	call_count++;
+	NSLog(@"[godot-lib] iphone_main call #%d, argc=%d", call_count, argc);
 	size_t len = strlen(argv[0]);
 
 	while (len--) {

--- a/platform/iphone/godot_iphone.mm
+++ b/platform/iphone/godot_iphone.mm
@@ -103,8 +103,15 @@ int iphone_main(int argc, char **argv, String data_dir) {
 	argc = add_cmdline(argc, fargv);
 
 	printf("os created\n");
+	// Instrumentation for the "keep RN animating while Godot boots"
+	// investigation. Times Main::setup specifically (the type-registration +
+	// project-parsing phase, which on big apps is the long pole and the
+	// prime candidate for running off the UI thread). setup2 / start are
+	// timed separately in godot_view_renderer.mm.
+	NSDate *t0 = [NSDate date];
 	Error err = Main::setup(fargv[0], argc - 1, &fargv[1], false);
-	printf("setup %i\n", err);
+	NSTimeInterval dt = [[NSDate date] timeIntervalSinceDate:t0];
+	NSLog(@"[godot-lib] Main::setup took %.3fs (err=%d)", dt, (int)err);
 	if (err != OK) {
 		return 255;
 	}

--- a/platform/iphone/godot_view.mm
+++ b/platform/iphone/godot_view.mm
@@ -31,6 +31,7 @@
 #import "godot_view.h"
 
 #include "core/project_settings.h"
+#include "host_input_queue.h"
 #include "os_iphone.h"
 #include "servers/audio_server.h"
 
@@ -348,6 +349,11 @@ static const int max_touches = 8;
 	}
 }
 
+// Touch callbacks fire on the UIKit main thread. We do NOT reach into Godot
+// directly (InputDefault is owned by the engine worker that drives
+// Main::iteration); instead, drop a POD record into HostInputQueue and let
+// OSIPhone::iterate drain it on the worker. Same pattern Android already uses
+// via GLSurfaceView.queueEvent.
 - (void)touchesBegan:(NSSet *)touchesSet withEvent:(UIEvent *)event {
 	NSArray *tlist = [event.allTouches allObjects];
 	for (unsigned int i = 0; i < [tlist count]; i++) {
@@ -356,7 +362,7 @@ static const int max_touches = 8;
 			int tid = [self getTouchIDForTouch:touch];
 			ERR_FAIL_COND(tid == -1);
 			CGPoint touchPoint = [touch locationInView:self];
-			OSIPhone::get_singleton()->touch_press(tid, touchPoint.x * self.contentScaleFactor, touchPoint.y * self.contentScaleFactor, true, touch.tapCount > 1);
+			HostInput::touch_press(tid, touchPoint.x * self.contentScaleFactor, touchPoint.y * self.contentScaleFactor, true, touch.tapCount > 1);
 		}
 	}
 }
@@ -370,7 +376,7 @@ static const int max_touches = 8;
 			ERR_FAIL_COND(tid == -1);
 			CGPoint touchPoint = [touch locationInView:self];
 			CGPoint prev_point = [touch previousLocationInView:self];
-			OSIPhone::get_singleton()->touch_drag(tid, prev_point.x * self.contentScaleFactor, prev_point.y * self.contentScaleFactor, touchPoint.x * self.contentScaleFactor, touchPoint.y * self.contentScaleFactor);
+			HostInput::touch_drag(tid, prev_point.x * self.contentScaleFactor, prev_point.y * self.contentScaleFactor, touchPoint.x * self.contentScaleFactor, touchPoint.y * self.contentScaleFactor);
 		}
 	}
 }
@@ -384,7 +390,7 @@ static const int max_touches = 8;
 			ERR_FAIL_COND(tid == -1);
 			[self removeTouch:touch];
 			CGPoint touchPoint = [touch locationInView:self];
-			OSIPhone::get_singleton()->touch_press(tid, touchPoint.x * self.contentScaleFactor, touchPoint.y * self.contentScaleFactor, false, false);
+			HostInput::touch_press(tid, touchPoint.x * self.contentScaleFactor, touchPoint.y * self.contentScaleFactor, false, false);
 		}
 	}
 }
@@ -396,7 +402,7 @@ static const int max_touches = 8;
 			UITouch *touch = [tlist objectAtIndex:i];
 			int tid = [self getTouchIDForTouch:touch];
 			ERR_FAIL_COND(tid == -1);
-			OSIPhone::get_singleton()->touches_cancelled(tid);
+			HostInput::touch_cancel(tid);
 		}
 	}
 	[self clearTouches];

--- a/platform/iphone/godot_view_renderer.mm
+++ b/platform/iphone/godot_view_renderer.mm
@@ -68,7 +68,14 @@
 
 	if (!self.hasStartedMain) {
 		self.hasStartedMain = YES;
+		// Instrumentation for off-main-boot investigation. OSIPhone::start()
+		// calls Main::start() which loads the main scene + runs first-pass
+		// GDScript _ready, allocating GL resources. Candidate for running
+		// off main in Option 1b (requires GL context handoff).
+		NSDate *t0 = [NSDate date];
 		OSIPhone::get_singleton()->start();
+		NSTimeInterval dt = [[NSDate date] timeIntervalSinceDate:t0];
+		NSLog(@"[godot-lib] OSIPhone::start (→ Main::start, scene load) took %.3fs", dt);
 		return YES;
 	}
 
@@ -80,7 +87,13 @@
 - (void)setupProjectData {
 	self.hasFinishedProjectDataSetup = YES;
 
+	// Instrumentation for off-main-boot investigation. Main::setup2 inits
+	// VisualServer / rasterizer, which means GL calls — moving this off
+	// main requires an EAGLContext current on the boot thread.
+	NSDate *t0 = [NSDate date];
 	Main::setup2();
+	NSTimeInterval dt = [[NSDate date] timeIntervalSinceDate:t0];
+	NSLog(@"[godot-lib] Main::setup2 took %.3fs", dt);
 
 	// this might be necessary before here
 	NSDictionary *dict = [[NSBundle mainBundle] infoDictionary];

--- a/platform/iphone/host_input_queue.h
+++ b/platform/iphone/host_input_queue.h
@@ -1,0 +1,80 @@
+/*************************************************************************/
+/*  host_input_queue.h                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+
+#ifndef HOST_INPUT_QUEUE_H
+#define HOST_INPUT_QUEUE_H
+
+#ifdef IPHONE_ENABLED
+
+#include <atomic>
+#include <stdint.h>
+
+// Single-producer / single-consumer ring buffer used to ferry UIKit-thread
+// input (touch/keyboard/joypad) into the engine worker thread that drives
+// Main::iteration. Events are POD; the consumer rebuilds Ref<InputEvent>s
+// locally so reference-counting stays thread-confined.
+//
+// Producer: any UIKit-callback context (touchesBegan/Moved/Ended,
+// UITextView delegate, GCController valueChangedHandler — all main-queue
+// by default).
+// Consumer: OSIPhone::iterate(), which calls drain() before Main::iteration.
+//
+// Capacity is fixed and modest: at 60Hz, even rapid multi-touch sessions
+// don't exceed a few dozen events per frame. Overflow drops events.
+struct HostInputEvent {
+	enum Kind {
+		KIND_TOUCH_PRESS,
+		KIND_TOUCH_DRAG,
+		KIND_TOUCH_CANCEL,
+		KIND_KEY,
+	};
+	Kind kind;
+	int idx;
+	float x, y, prev_x, prev_y;
+	bool pressed;
+	bool doubleclick;
+	uint32_t key;
+};
+
+class HostInputQueue {
+public:
+	static HostInputQueue &get();
+
+	// Push from the producer thread. Returns false if the ring is full.
+	bool push(const HostInputEvent &e);
+
+	// Drain everything currently queued, dispatching each event to OSIPhone.
+	// Must be called from the engine worker thread (the one that owns
+	// InputDefault::parse_input_event).
+	void drain();
+
+private:
+	HostInputQueue();
+	HostInputQueue(const HostInputQueue &) = delete;
+	HostInputQueue &operator=(const HostInputQueue &) = delete;
+
+	static const uint32_t CAPACITY = 1024;
+	HostInputEvent ring[CAPACITY];
+	std::atomic<uint32_t> head; // next slot the producer writes
+	std::atomic<uint32_t> tail; // next slot the consumer reads
+};
+
+// Convenience producer entry points for UIKit callsites. These build a
+// HostInputEvent and push it; safe to call from any thread.
+namespace HostInput {
+
+void touch_press(int idx, float x, float y, bool pressed, bool doubleclick);
+void touch_drag(int idx, float prev_x, float prev_y, float x, float y);
+void touch_cancel(int idx);
+void key(uint32_t scancode, bool pressed);
+
+} // namespace HostInput
+
+#endif // IPHONE_ENABLED
+
+#endif // HOST_INPUT_QUEUE_H

--- a/platform/iphone/host_input_queue.mm
+++ b/platform/iphone/host_input_queue.mm
@@ -1,0 +1,107 @@
+/*************************************************************************/
+/*  host_input_queue.mm                                                  */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+
+#ifdef IPHONE_ENABLED
+
+#include "host_input_queue.h"
+
+#include "os_iphone.h"
+
+HostInputQueue::HostInputQueue() :
+		head(0), tail(0) {
+}
+
+HostInputQueue &HostInputQueue::get() {
+	static HostInputQueue instance;
+	return instance;
+}
+
+bool HostInputQueue::push(const HostInputEvent &e) {
+	uint32_t h = head.load(std::memory_order_relaxed);
+	uint32_t t = tail.load(std::memory_order_acquire);
+	if (h - t >= CAPACITY) {
+		// Full — drop. Touch backlog this deep means the engine thread is
+		// stalled; further events would be stale by the time we drain.
+		return false;
+	}
+	ring[h % CAPACITY] = e;
+	head.store(h + 1, std::memory_order_release);
+	return true;
+}
+
+void HostInputQueue::drain() {
+	OSIPhone *os = OSIPhone::get_singleton();
+	if (!os) {
+		return;
+	}
+
+	uint32_t t = tail.load(std::memory_order_relaxed);
+	uint32_t h = head.load(std::memory_order_acquire);
+	while (t != h) {
+		const HostInputEvent &e = ring[t % CAPACITY];
+		switch (e.kind) {
+			case HostInputEvent::KIND_TOUCH_PRESS:
+				os->touch_press(e.idx, (int)e.x, (int)e.y, e.pressed, e.doubleclick);
+				break;
+			case HostInputEvent::KIND_TOUCH_DRAG:
+				os->touch_drag(e.idx, (int)e.prev_x, (int)e.prev_y, (int)e.x, (int)e.y);
+				break;
+			case HostInputEvent::KIND_TOUCH_CANCEL:
+				os->touches_cancelled(e.idx);
+				break;
+			case HostInputEvent::KIND_KEY:
+				os->key(e.key, e.pressed);
+				break;
+		}
+		t++;
+	}
+	tail.store(t, std::memory_order_release);
+}
+
+namespace HostInput {
+
+void touch_press(int idx, float x, float y, bool pressed, bool doubleclick) {
+	HostInputEvent e = {};
+	e.kind = HostInputEvent::KIND_TOUCH_PRESS;
+	e.idx = idx;
+	e.x = x;
+	e.y = y;
+	e.pressed = pressed;
+	e.doubleclick = doubleclick;
+	HostInputQueue::get().push(e);
+}
+
+void touch_drag(int idx, float prev_x, float prev_y, float x, float y) {
+	HostInputEvent e = {};
+	e.kind = HostInputEvent::KIND_TOUCH_DRAG;
+	e.idx = idx;
+	e.prev_x = prev_x;
+	e.prev_y = prev_y;
+	e.x = x;
+	e.y = y;
+	HostInputQueue::get().push(e);
+}
+
+void touch_cancel(int idx) {
+	HostInputEvent e = {};
+	e.kind = HostInputEvent::KIND_TOUCH_CANCEL;
+	e.idx = idx;
+	HostInputQueue::get().push(e);
+}
+
+void key(uint32_t scancode, bool pressed) {
+	HostInputEvent e = {};
+	e.kind = HostInputEvent::KIND_KEY;
+	e.key = scancode;
+	e.pressed = pressed;
+	HostInputQueue::get().push(e);
+}
+
+} // namespace HostInput
+
+#endif // IPHONE_ENABLED

--- a/platform/iphone/ios.h
+++ b/platform/iphone/ios.h
@@ -54,6 +54,7 @@ public:
 
 	void share_data(const String &text, const String &image_path);
 	int get_interface_orientation() const;
+	void goto_host(const String &reason);
 	iOS();
 };
 

--- a/platform/iphone/ios.h
+++ b/platform/iphone/ios.h
@@ -55,6 +55,7 @@ public:
 	void share_data(const String &text, const String &image_path);
 	int get_interface_orientation() const;
 	void goto_host(const String &reason);
+	void host_ready(const String &reason);
 	iOS();
 };
 

--- a/platform/iphone/ios.mm
+++ b/platform/iphone/ios.mm
@@ -49,6 +49,7 @@ void iOS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("send_notification", "indifiter", "title", "body", "time_offset"), &iOS::send_notification);
 	ClassDB::bind_method(D_METHOD("cancel_notifications", "identifier_arr"), &iOS::cancel_notifications);
 	ClassDB::bind_method(D_METHOD("goto_host", "reason"), &iOS::goto_host);
+	ClassDB::bind_method(D_METHOD("host_ready", "reason"), &iOS::host_ready);
 };
 
 void iOS::alert(const char *p_alert, const char *p_title) {
@@ -177,6 +178,20 @@ void iOS::goto_host(const String &reason) {
 														object:nil
 													  userInfo:@{ @"reason" : ns_reason ?: @"" }];
 	NSLog(@"[iOS] goto_host — post returned");
+}
+
+void iOS::host_ready(const String &reason) {
+	// Posts "GodotHostReady" on the default NSNotificationCenter so host apps
+	// (e.g. a React Native shell) know the engine has its first content frame up
+	// and can swap from a boot screen to the Godot view immediately, instead of
+	// waiting on a fixed timer. Mirrors goto_host's GodotRequestExit channel.
+	// No-op when no host is observing; harmless in standalone builds.
+	NSString *ns_reason = [NSString stringWithUTF8String:reason.utf8().get_data()];
+	NSLog(@"[iOS] host_ready(\"%@\") — posting NSNotification", ns_reason ?: @"");
+	[[NSNotificationCenter defaultCenter] postNotificationName:@"GodotHostReady"
+														object:nil
+													  userInfo:@{ @"reason" : ns_reason ?: @"" }];
+	NSLog(@"[iOS] host_ready — post returned");
 }
 
 void iOS::set_background_color(float r, float g, float b, float a)

--- a/platform/iphone/ios.mm
+++ b/platform/iphone/ios.mm
@@ -172,9 +172,11 @@ void iOS::goto_host(const String &reason) {
 	// without Godot needing a direct reference to the host. No-op when no host
 	// is observing; harmless in standalone builds.
 	NSString *ns_reason = [NSString stringWithUTF8String:reason.utf8().get_data()];
+	NSLog(@"[iOS] goto_host(\"%@\") — posting NSNotification", ns_reason ?: @"");
 	[[NSNotificationCenter defaultCenter] postNotificationName:@"GodotRequestExit"
 														object:nil
 													  userInfo:@{ @"reason" : ns_reason ?: @"" }];
+	NSLog(@"[iOS] goto_host — post returned");
 }
 
 void iOS::set_background_color(float r, float g, float b, float a)

--- a/platform/iphone/ios.mm
+++ b/platform/iphone/ios.mm
@@ -48,6 +48,7 @@ void iOS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_app_version"), &iOS::get_app_version);
 	ClassDB::bind_method(D_METHOD("send_notification", "indifiter", "title", "body", "time_offset"), &iOS::send_notification);
 	ClassDB::bind_method(D_METHOD("cancel_notifications", "identifier_arr"), &iOS::cancel_notifications);
+	ClassDB::bind_method(D_METHOD("goto_host", "reason"), &iOS::goto_host);
 };
 
 void iOS::alert(const char *p_alert, const char *p_title) {
@@ -163,6 +164,17 @@ UIViewController *root_controller = AppDelegate.viewController;
     }
     [root_controller presentViewController:avc animated:true completion:nil];
 
+}
+
+void iOS::goto_host(const String &reason) {
+	// Posts "GodotRequestExit" on the default NSNotificationCenter so host apps
+	// (e.g. a React Native shell) can observe it and swap the engine view out
+	// without Godot needing a direct reference to the host. No-op when no host
+	// is observing; harmless in standalone builds.
+	NSString *ns_reason = [NSString stringWithUTF8String:reason.utf8().get_data()];
+	[[NSNotificationCenter defaultCenter] postNotificationName:@"GodotRequestExit"
+														object:nil
+													  userInfo:@{ @"reason" : ns_reason ?: @"" }];
 }
 
 void iOS::set_background_color(float r, float g, float b, float a)

--- a/platform/iphone/ios.mm
+++ b/platform/iphone/ios.mm
@@ -50,6 +50,10 @@ void iOS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("cancel_notifications", "identifier_arr"), &iOS::cancel_notifications);
 	ClassDB::bind_method(D_METHOD("goto_host", "reason"), &iOS::goto_host);
 	ClassDB::bind_method(D_METHOD("host_ready", "reason"), &iOS::host_ready);
+	// Inbound host→engine channel, the mirror of host_ready's outbound notify.
+	// A host shell (e.g. React Native) posts "GodotHostCommand"; we re-emit it
+	// as this signal so GDScript can react (e.g. the boot route chosen in React).
+	ADD_SIGNAL(MethodInfo("host_command", PropertyInfo(Variant::STRING, "name")));
 };
 
 void iOS::alert(const char *p_alert, const char *p_title) {
@@ -202,4 +206,27 @@ void iOS::set_background_color(float r, float g, float b, float a)
 	// 	[UIColor colorWithRed:r green:g blue:b alpha:a];
 }
 
-iOS::iOS(){};
+// Observer token for the inbound "GodotHostCommand" channel. The iOS singleton
+// is process-lifetime, so this is registered once and never removed.
+static id _host_command_observer = nil;
+
+iOS::iOS() {
+	// Inbound host→engine channel, the mirror of host_ready's outbound notify.
+	// A host shell (e.g. React Native) posts "GodotHostCommand" with a "name";
+	// we hop to the engine thread (call_deferred → MessageQueue, flushed on the
+	// engine loop) and emit `host_command` so GDScript can react. The block runs
+	// on the posting (main) thread; call_deferred makes the hand-off safe. No-op
+	// in standalone builds where nothing posts the notification.
+	iOS *singleton = this;
+	_host_command_observer = [[NSNotificationCenter defaultCenter]
+			addObserverForName:@"GodotHostCommand"
+						object:nil
+						 queue:nil
+					usingBlock:^(NSNotification *note) {
+				NSString *ns_name = note.userInfo[@"name"];
+				const char *c_name = ns_name ? [ns_name UTF8String] : "";
+				String name = String::utf8(c_name ? c_name : "");
+				NSLog(@"[iOS] GodotHostCommand received: \"%@\"", ns_name ?: @"");
+				singleton->call_deferred("emit_signal", "host_command", name);
+			}];
+};

--- a/platform/iphone/keyboard_input_view.mm
+++ b/platform/iphone/keyboard_input_view.mm
@@ -31,6 +31,7 @@
 #import "keyboard_input_view.h"
 
 #include "core/os/keyboard.h"
+#include "host_input_queue.h"
 #include "os_iphone.h"
 
 @interface GodotKeyboardInputView () <UITextViewDelegate>
@@ -122,8 +123,8 @@
 
 - (void)deleteText:(NSInteger)charactersToDelete {
 	for (int i = 0; i < charactersToDelete; i++) {
-		OSIPhone::get_singleton()->key(KEY_BACKSPACE, true);
-		OSIPhone::get_singleton()->key(KEY_BACKSPACE, false);
+		HostInput::key(KEY_BACKSPACE, true);
+		HostInput::key(KEY_BACKSPACE, false);
 	}
 }
 
@@ -145,8 +146,8 @@
 				break;
 		}
 
-		OSIPhone::get_singleton()->key(character, true);
-		OSIPhone::get_singleton()->key(character, false);
+		HostInput::key(character, true);
+		HostInput::key(character, false);
 	}
 }
 

--- a/platform/iphone/library_entry.h
+++ b/platform/iphone/library_entry.h
@@ -1,0 +1,62 @@
+/*************************************************************************/
+/*  library_entry.h                                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifdef IOS_LIBRARY_MODE
+
+#import <UIKit/UIKit.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Initialize the Godot engine for host-embedded use. Host apps (e.g. a React Native
+// shell) call this once before asking for a view controller. cmdline may be nil
+// (equivalent to no arguments). dataDir must be a writable path, typically
+// NSDocumentDirectory. Returns 0 on success. Subsequent calls no-op.
+int godot_library_start(NSArray<NSString *> *_Nullable cmdline, NSString *_Nonnull dataDir);
+
+// Build and return a GodotViewController configured the same way the non-library
+// path does it (CADisplayLink enabled, 60Hz, fullscreen presentation style). Also
+// registers the VC with AppDelegate so the rest of the engine can reach it via
+// AppDelegate.viewController. Ownership: caller retains the returned VC. Safe to
+// call multiple times; the most recently returned VC becomes the registered one.
+UIViewController *_Nonnull godot_library_make_view_controller(void);
+
+// Placeholder teardown. iphone_finish() is called but OSIPhone/Main in the 3.3 fork
+// are not designed for re-init, so this is effectively one-shot (process-end only).
+// Kept as a symbol so hosts can wire it up now and we can harden the teardown path
+// later without breaking their code.
+void godot_library_stop(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // IOS_LIBRARY_MODE

--- a/platform/iphone/library_entry.h
+++ b/platform/iphone/library_entry.h
@@ -36,18 +36,50 @@
 extern "C" {
 #endif
 
-// Initialize the Godot engine for host-embedded use. Host apps (e.g. a React Native
-// shell) call this once before asking for a view controller. cmdline may be nil
-// (equivalent to no arguments). dataDir must be a writable path, typically
-// NSDocumentDirectory. Returns 0 on success. Subsequent calls no-op.
+// Spawn the engine worker thread that runs Main::setup off the calling
+// (UIKit main) thread. Returns IMMEDIATELY, before Main::setup has finished —
+// the host can render a spinner / progress UI while the engine boots.
+//
+// Returns 0 on successful spawn, !=0 on pthread_create failure. Note: a
+// successful spawn does NOT mean engine setup succeeded — that may still
+// fail asynchronously. Observe the GodotLibraryReadyNotification (below) or
+// poll godot_library_is_ready() for completion + result code.
+//
+// Subsequent calls after a successful first call are no-ops.
+//
+// cmdline may be nil. Pass --path <dir> to point Main::setup at a project
+// folder, or --main-pack <pack.pck> for an exported pack. dataDir must be a
+// writable path, typically NSDocumentDirectory.
 int godot_library_start(NSArray<NSString *> *_Nullable cmdline, NSString *_Nonnull dataDir);
 
 // Build and return a GodotViewController configured the same way the non-library
 // path does it (CADisplayLink enabled, 60Hz, fullscreen presentation style). Also
 // registers the VC with AppDelegate so the rest of the engine can reach it via
-// AppDelegate.viewController. Ownership: caller retains the returned VC. Safe to
-// call multiple times; the most recently returned VC becomes the registered one.
+// AppDelegate.viewController.
+//
+// IMPORTANT: this call BLOCKS the calling thread until Main::setup finishes
+// on the engine worker, because it reads ProjectSettings (display.iOS/...).
+// In practice that means: call godot_library_start eagerly at app launch,
+// then call this just before swapping to the Godot view — by then setup is
+// usually done and the wait is zero. If you call it sooner it just blocks
+// until ready, no race.
+//
+// Ownership: caller retains the returned VC. Safe to call multiple times;
+// the most recently returned VC becomes the registered one.
 UIViewController *_Nonnull godot_library_make_view_controller(void);
+
+// Returns:
+//   0  Setup still in progress on the engine thread.
+//   1  Setup finished successfully.
+//  <0  Setup failed; absolute value is the error code from iphone_main.
+// Cheap to poll. Reads an atomic int.
+int godot_library_is_ready(void);
+
+// Posted on the default NSNotificationCenter once the engine worker finishes
+// Main::setup (or fails). userInfo[@"result"] is an NSNumber with the iphone_main
+// return code (0 = success, !=0 = failure). Posted on the engine thread, so
+// observers that touch UIKit must hop to dispatch_get_main_queue.
+extern NSNotificationName _Nonnull const GodotLibraryReadyNotification;
 
 // Placeholder teardown. iphone_finish() is called but OSIPhone/Main in the 3.3 fork
 // are not designed for re-init, so this is effectively one-shot (process-end only).

--- a/platform/iphone/library_entry.h
+++ b/platform/iphone/library_entry.h
@@ -55,6 +55,17 @@ UIViewController *_Nonnull godot_library_make_view_controller(void);
 // later without breaking their code.
 void godot_library_stop(void);
 
+// Start/stop the CADisplayLink, audio, and video playback. Hosts should call
+// godot_library_focus_in() after making the Godot VC visible (root-VC swap,
+// view-becomes-window), and godot_library_focus_out() before hiding it. The
+// fork's standalone entry wires these to applicationWillResignActive /
+// applicationDidBecomeActive; library-mode hosts own their own app delegate
+// and must forward the calls themselves. Safe to call before engine start
+// (no-op). Between focus_out and the next focus_in, Godot stops rendering
+// and pauses its audio driver.
+void godot_library_focus_in(void);
+void godot_library_focus_out(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/iphone/library_entry.mm
+++ b/platform/iphone/library_entry.mm
@@ -5,28 +5,6 @@
 /*                           GODOT ENGINE                                */
 /*                      https://godotengine.org                          */
 /*************************************************************************/
-/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
-/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
-/*                                                                       */
-/* Permission is hereby granted, free of charge, to any person obtaining */
-/* a copy of this software and associated documentation files (the       */
-/* "Software"), to deal in the Software without restriction, including   */
-/* without limitation the rights to use, copy, modify, merge, publish,   */
-/* distribute, sublicense, and/or sell copies of the Software, and to    */
-/* permit persons to whom the Software is furnished to do so, subject to */
-/* the following conditions:                                             */
-/*                                                                       */
-/* The above copyright notice and this permission notice shall be        */
-/* included in all copies or substantial portions of the Software.       */
-/*                                                                       */
-/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
-/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
-/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
-/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
-/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
-/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
-/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
-/*************************************************************************/
 
 #ifdef IOS_LIBRARY_MODE
 
@@ -36,23 +14,52 @@
 #import "godot_view.h"
 #import "view_controller.h"
 
+#include "core/os/thread.h"
 #include "core/project_settings.h"
 #include "core/ustring.h"
 #include "os_iphone.h"
+
+#include <atomic>
+#include <pthread.h>
 
 #define kRenderingFrequency 60
 
 extern int iphone_main(int, char **, String);
 extern void iphone_finish();
 
-static BOOL g_started = NO;
+NSNotificationName const GodotLibraryReadyNotification = @"GodotLibraryReadyNotification";
 
-// Backing store for the synthesized argv. iphone_main does not take ownership —
-// it reads argv[0] for chdir and hands the rest to Main::setup. We keep the
-// buffer alive for the process lifetime since the engine assumes argv outlives
-// startup, same as the UIApplicationMain path.
+// === Boot state ============================================================
+//
+// godot_library_start runs on the host's UIKit main thread and must return
+// quickly so RN can keep its UI responsive — including showing a splash /
+// spinner while the engine boots. The engine itself must not touch the UIKit
+// main thread once running. Resolution: godot_library_start spawns a
+// dedicated pthread (the "engine thread") and returns immediately. The
+// engine thread runs Main::setup on itself, then signals readiness via:
+//   - flipping g_ready_state to a non-zero value (poll API), and
+//   - posting GodotLibraryReadyNotification (push API).
+// godot_library_make_view_controller blocks on g_setup_done_sem so a host
+// that doesn't poll/observe can just call it lazily and pay the wait cost
+// only if setup hasn't finished yet (usually zero by then).
+//
+// From the moment focus_in fires onward, every engine-touching call is
+// marshalled onto the engine thread's CFRunLoop. CADisplayLink attaches to
+// that runloop too, so drawView / Main::iteration fire off-main.
+
+static BOOL g_started = NO;
+static pthread_t g_engine_thread;
+static CFRunLoopRef g_engine_runloop = NULL;
+static dispatch_semaphore_t g_setup_done_sem = NULL;
+static int g_setup_result = -1;
+// 0 = not done, 1 = success, <0 = -|err|. Atomic so the host's poll path
+// doesn't need to take any locks.
+static std::atomic<int> g_ready_state{ 0 };
+
+// argv backing — same lifetime requirement as before.
 static char **g_argv = NULL;
 static int g_argc = 0;
+static NSString *g_data_dir = nil;
 
 static void build_argv_from_array(NSArray<NSString *> *cmdline) {
 	NSString *exe_path = [[NSBundle mainBundle] executablePath] ?: @"godot";
@@ -71,41 +78,160 @@ static void build_argv_from_array(NSArray<NSString *> *cmdline) {
 	g_argv[g_argc] = NULL;
 }
 
+// CFRunLoopSource trampoline — empty perform; only here so the runloop has
+// at least one source attached and CFRunLoopRun() doesn't return immediately
+// before CADisplayLink gets installed via focus_in.
+static void engine_runloop_keepalive_perform(void *) {
+}
+
+static void *engine_thread_main(void *) {
+	pthread_setname_np("godot.engine");
+
+	@autoreleasepool {
+		// Pin Godot's notion of "main thread" to THIS pthread, so every
+		// is_main_thread() check across the engine (GDScript, MessageQueue,
+		// VisualServer wrap-MT, etc.) treats this thread as main. Done before
+		// Main::setup so register_core_types runs with the correct identity.
+		Thread::make_main_thread();
+
+		g_engine_runloop = CFRunLoopGetCurrent();
+
+		NSDate *t0 = [NSDate date];
+		int err = iphone_main(g_argc, g_argv, String::utf8([g_data_dir UTF8String]));
+		NSTimeInterval dt = [[NSDate date] timeIntervalSinceDate:t0];
+		NSLog(@"[godot-lib] engine thread: iphone_main returned %d after %.3fs", err, dt);
+
+		g_setup_result = err;
+
+		if (err == 0) {
+			bool keep_screen_on = bool(GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true));
+			NSLog(@"[godot-lib] keep_screen_on=%d", keep_screen_on);
+			OSIPhone::get_singleton()->set_keep_screen_on(keep_screen_on);
+		}
+
+		// Publish readiness BEFORE the notification, so observers that re-
+		// query state (e.g. via godot_library_is_ready) see the final value.
+		// 1 = success; <0 = -|err| failure code.
+		int ready_value;
+		if (err == 0) {
+			ready_value = 1;
+		} else {
+			int abs_err = err < 0 ? -err : err;
+			ready_value = -abs_err;
+			if (ready_value == 0) {
+				ready_value = -1;
+			}
+		}
+		g_ready_state.store(ready_value, std::memory_order_release);
+
+		// Release godot_library_make_view_controller and any other callers
+		// that chose the "block and wait" API. dispatch_semaphore_signal is
+		// idempotent in the sense that subsequent waits return immediately
+		// once the count is non-zero — we bump once per call by signaling
+		// only here.
+		dispatch_semaphore_signal(g_setup_done_sem);
+
+		// Push notification so hosts that opted into observation get pinged.
+		// Posted on the engine thread; observers should not assume main.
+		[[NSNotificationCenter defaultCenter]
+				postNotificationName:GodotLibraryReadyNotification
+							  object:nil
+							userInfo:@{ @"result" : @(err) }];
+
+		if (err != 0) {
+			return NULL;
+		}
+
+		// Keep the runloop alive even with no CADisplayLink attached yet.
+		// Blocks posted via CFRunLoopPerformBlock+CFRunLoopWakeUp run here;
+		// CADisplayLink callbacks attached to this runloop run here.
+		CFRunLoopSourceContext ctx = { 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, &engine_runloop_keepalive_perform };
+		CFRunLoopSourceRef src = CFRunLoopSourceCreate(kCFAllocatorDefault, 0, &ctx);
+		CFRunLoopAddSource(g_engine_runloop, src, kCFRunLoopCommonModes);
+		CFRelease(src);
+
+		CFRunLoopRun();
+	}
+
+	return NULL;
+}
+
+// Post a block to the engine thread's runloop and wake it up. Safe to call
+// from any thread; returns immediately.
+static void godot_lib_dispatch_to_engine(dispatch_block_t block) {
+	if (g_engine_runloop == NULL) {
+		// Engine thread not started or aborted during setup. Drop.
+		return;
+	}
+	CFRunLoopPerformBlock(g_engine_runloop, kCFRunLoopCommonModes, block);
+	CFRunLoopWakeUp(g_engine_runloop);
+}
+
 int godot_library_start(NSArray<NSString *> *cmdline, NSString *dataDir) {
 	NSLog(@"[godot-lib] godot_library_start called, g_started=%d", g_started);
 	if (g_started) {
+		// Idempotent: return current readiness so a host that polls only
+		// after re-issuing start gets a sensible answer. 0 still means
+		// "spawn ok" in the success case — readiness is a separate query.
 		return 0;
 	}
 	if (dataDir == nil) {
 		return -1;
 	}
 
-	// Flip the guard BEFORE calling into iphone_main. iphone_main /
-	// Main::setup / register_core_types mutates process-wide singletons
+	// Flip the guard BEFORE spawning the engine thread. Re-entry into
+	// register_core_types / Main::setup mutates process-wide singletons
 	// (StringName::configured, IP::singleton, InputMap::singleton, ...);
-	// a crash or exception thrown anywhere inside would leave the engine
-	// half-initialized. If the host retries enter() we must NOT reach
-	// register_core_types again — the ERR_FAIL_COND messages are harmless
-	// but a second IP::create / InputMap() hits an abort in some
-	// configurations.
+	// any retry after failure would double-allocate them.
 	g_started = YES;
 	build_argv_from_array(cmdline);
+	g_data_dir = dataDir;
 
-	int err = iphone_main(g_argc, g_argv, String::utf8([dataDir UTF8String]));
-	NSLog(@"[godot-lib] iphone_main returned err=%d", err);
-	if (err != 0) {
-		return err;
+	g_setup_done_sem = dispatch_semaphore_create(0);
+
+	pthread_attr_t attr;
+	pthread_attr_init(&attr);
+	// Bigger stack than the 512KB default — Main::setup recurses through
+	// project parsing and registers a lot of types.
+	pthread_attr_setstacksize(&attr, 4 * 1024 * 1024);
+	int rc = pthread_create(&g_engine_thread, &attr, engine_thread_main, NULL);
+	pthread_attr_destroy(&attr);
+	if (rc != 0) {
+		NSLog(@"[godot-lib] pthread_create failed: %d", rc);
+		g_started = NO;
+		return -2;
 	}
 
-	bool keep_screen_on = bool(GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true));
-	NSLog(@"[godot-lib] keep_screen_on=%d", keep_screen_on);
-	OSIPhone::get_singleton()->set_keep_screen_on(keep_screen_on);
-
-	NSLog(@"[godot-lib] godot_library_start done");
+	// Return immediately. The host gets back to its event loop / can render
+	// a spinner. Readiness arrives via GodotLibraryReadyNotification or by
+	// polling godot_library_is_ready(); make_view_controller blocks if the
+	// host doesn't bother synchronising and just calls it eagerly.
+	NSLog(@"[godot-lib] engine thread spawned; setup running off-main");
 	return 0;
 }
 
+int godot_library_is_ready(void) {
+	return g_ready_state.load(std::memory_order_acquire);
+}
+
 UIViewController *godot_library_make_view_controller(void) {
+	// UIViewController/UIView creation MUST be on UIKit main. The host
+	// (godot_library_make_view_controller's caller) is on main. We keep that
+	// invariant. The engine thread will only later attach a CADisplayLink to
+	// the GodotView via focus_in (marshalled onto the engine runloop).
+	//
+	// Setup-gating: this method reads ProjectSettings ("display.iOS/..."),
+	// which only exists after Main::setup completes on the engine thread.
+	// If the host calls this before readiness, block until then. Past
+	// readiness the wait is a no-op (the semaphore stays signalled because
+	// nothing else consumes it).
+	if (g_ready_state.load(std::memory_order_acquire) == 0) {
+		dispatch_semaphore_wait(g_setup_done_sem, DISPATCH_TIME_FOREVER);
+		// Re-signal so a subsequent call (e.g. host re-creates the VC)
+		// doesn't deadlock. The semaphore is intentionally used as a
+		// one-way latch, not a counter.
+		dispatch_semaphore_signal(g_setup_done_sem);
+	}
 	ViewController *vc = [[ViewController alloc] init];
 	vc.godotView.useCADisplayLink = bool(GLOBAL_DEF("display.iOS/use_cadisplaylink", true)) ? YES : NO;
 	vc.godotView.renderingInterval = 1.0 / kRenderingFrequency;
@@ -114,12 +240,7 @@ UIViewController *godot_library_make_view_controller(void) {
 	[AppDelegate setViewController:vc];
 
 	// Rendering does NOT start here. Hosts call godot_library_focus_in()
-	// after the VC becomes visible (root-VC swap completes, view is added
-	// to a window). This matches the on_focus_in / on_focus_out pattern
-	// Godot's standalone AppDelegate uses via applicationDidBecomeActive /
-	// applicationWillResignActive, but gives the library-mode host control
-	// over when the CADisplayLink spins.
-
+	// after the VC becomes visible (root-VC swap, view-becomes-window).
 	return vc;
 }
 
@@ -127,23 +248,35 @@ void godot_library_focus_in(void) {
 	if (!g_started) {
 		return;
 	}
-	NSLog(@"[godot-lib] focus_in — resuming rendering/audio");
-	OSIPhone::get_singleton()->on_focus_in();
+	NSLog(@"[godot-lib] focus_in — hopping to engine thread");
+	godot_lib_dispatch_to_engine(^{
+		// Runs on engine thread. on_focus_in calls
+		// [godotView startRendering], which adds the CADisplayLink to
+		// [NSRunLoop currentRunLoop] — i.e. THIS thread's runloop. From now
+		// on, drawView / Main::iteration fire here, off-main.
+		OSIPhone::get_singleton()->on_focus_in();
+	});
 }
 
 void godot_library_focus_out(void) {
 	if (!g_started) {
 		return;
 	}
-	NSLog(@"[godot-lib] focus_out — pausing rendering/audio");
-	OSIPhone::get_singleton()->on_focus_out();
+	NSLog(@"[godot-lib] focus_out — hopping to engine thread");
+	godot_lib_dispatch_to_engine(^{
+		OSIPhone::get_singleton()->on_focus_out();
+	});
 }
 
 void godot_library_stop(void) {
 	if (!g_started) {
 		return;
 	}
-	iphone_finish();
+	// One-shot: OSIPhone/Main in 3.3 are not reinit-safe. Kept as a stub for
+	// host code; full teardown means killing the process.
+	godot_lib_dispatch_to_engine(^{
+		iphone_finish();
+	});
 	g_started = NO;
 }
 

--- a/platform/iphone/library_entry.mm
+++ b/platform/iphone/library_entry.mm
@@ -112,4 +112,23 @@ void godot_library_stop(void) {
 	g_started = NO;
 }
 
+// No-op stubs for the iOS plugin hooks. OSIPhone::start() /
+// OSIPhone::finalize() in os_iphone.mm call these, expecting the Godot
+// export pipeline to have generated concrete implementations
+// (platform/iphone/export/export.cpp:1442-1452). In library-mode builds
+// the host app isn't produced by that pipeline, so the symbols would be
+// undefined at link time. Provide empty definitions here so hosts that
+// don't ship any iOS plugins link cleanly. Declarations in os_iphone.h
+// use default C++ linkage (no extern "C"), so these must too — matching
+// the mangled symbol the caller expects.
+#if !defined(GODOT_IOS_PLUGINS_CUSTOM)
+
+void godot_ios_plugins_initialize() {
+}
+
+void godot_ios_plugins_deinitialize() {
+}
+
+#endif // !GODOT_IOS_PLUGINS_CUSTOM
+
 #endif // IOS_LIBRARY_MODE

--- a/platform/iphone/library_entry.mm
+++ b/platform/iphone/library_entry.mm
@@ -1,0 +1,115 @@
+/*************************************************************************/
+/*  library_entry.mm                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifdef IOS_LIBRARY_MODE
+
+#import "library_entry.h"
+
+#import "app_delegate.h"
+#import "godot_view.h"
+#import "view_controller.h"
+
+#include "core/project_settings.h"
+#include "core/ustring.h"
+#include "os_iphone.h"
+
+#define kRenderingFrequency 60
+
+extern int iphone_main(int, char **, String);
+extern void iphone_finish();
+
+static BOOL g_started = NO;
+
+// Backing store for the synthesized argv. iphone_main does not take ownership —
+// it reads argv[0] for chdir and hands the rest to Main::setup. We keep the
+// buffer alive for the process lifetime since the engine assumes argv outlives
+// startup, same as the UIApplicationMain path.
+static char **g_argv = NULL;
+static int g_argc = 0;
+
+static void build_argv_from_array(NSArray<NSString *> *cmdline) {
+	NSString *exe_path = [[NSBundle mainBundle] executablePath] ?: @"godot";
+	NSMutableArray<NSString *> *all = [NSMutableArray arrayWithObject:exe_path];
+	if (cmdline != nil) {
+		[all addObjectsFromArray:cmdline];
+	}
+	g_argc = (int)all.count;
+	g_argv = (char **)calloc(g_argc + 1, sizeof(char *));
+	for (int i = 0; i < g_argc; i++) {
+		const char *src = [all[i] UTF8String];
+		size_t n = strlen(src) + 1;
+		g_argv[i] = (char *)malloc(n);
+		memcpy(g_argv[i], src, n);
+	}
+	g_argv[g_argc] = NULL;
+}
+
+int godot_library_start(NSArray<NSString *> *cmdline, NSString *dataDir) {
+	if (g_started) {
+		return 0;
+	}
+	if (dataDir == nil) {
+		return -1;
+	}
+
+	build_argv_from_array(cmdline);
+
+	int err = iphone_main(g_argc, g_argv, String::utf8([dataDir UTF8String]));
+	if (err != 0) {
+		return err;
+	}
+
+	bool keep_screen_on = bool(GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true));
+	OSIPhone::get_singleton()->set_keep_screen_on(keep_screen_on);
+
+	g_started = YES;
+	return 0;
+}
+
+UIViewController *godot_library_make_view_controller(void) {
+	ViewController *vc = [[ViewController alloc] init];
+	vc.godotView.useCADisplayLink = bool(GLOBAL_DEF("display.iOS/use_cadisplaylink", true)) ? YES : NO;
+	vc.godotView.renderingInterval = 1.0 / kRenderingFrequency;
+	vc.modalPresentationStyle = UIModalPresentationFullScreen;
+
+	[AppDelegate setViewController:vc];
+
+	return vc;
+}
+
+void godot_library_stop(void) {
+	if (!g_started) {
+		return;
+	}
+	iphone_finish();
+	g_started = NO;
+}
+
+#endif // IOS_LIBRARY_MODE

--- a/platform/iphone/library_entry.mm
+++ b/platform/iphone/library_entry.mm
@@ -156,14 +156,16 @@ void godot_library_stop(void) {
 // don't ship any iOS plugins link cleanly. Declarations in os_iphone.h
 // use default C++ linkage (no extern "C"), so these must too — matching
 // the mangled symbol the caller expects.
-#if !defined(GODOT_IOS_PLUGINS_CUSTOM)
-
-void godot_ios_plugins_initialize() {
+//
+// Marked __attribute__((weak)) so a host that DOES ship a generated
+// dummy.cpp from the Godot iOS export pipeline (concrete implementations
+// calling register_<plugin>_types) overrides these stubs at link time
+// without a duplicate-symbol error, even when -force_load pulls every .o
+// from the library archive.
+__attribute__((weak)) void godot_ios_plugins_initialize() {
 }
 
-void godot_ios_plugins_deinitialize() {
+__attribute__((weak)) void godot_ios_plugins_deinitialize() {
 }
-
-#endif // !GODOT_IOS_PLUGINS_CUSTOM
 
 #endif // IOS_LIBRARY_MODE

--- a/platform/iphone/library_entry.mm
+++ b/platform/iphone/library_entry.mm
@@ -113,6 +113,16 @@ UIViewController *godot_library_make_view_controller(void) {
 
 	[AppDelegate setViewController:vc];
 
+	// In the standalone Godot iOS flow, OSIPhone::on_focus_in() (triggered
+	// by the Godot AppDelegate's applicationDidBecomeActive) is what starts
+	// the CADisplayLink and drives drawView → setupView → Main::start().
+	// Library-mode hosts (e.g. a React Native shell) have their own app
+	// delegate and never forward applicationDidBecomeActive here, so we
+	// kick off rendering manually. The host is still responsible for
+	// forwarding subsequent focus-in/out events; for this prototype a
+	// one-shot kick at mount time is enough.
+	OSIPhone::get_singleton()->on_focus_in();
+
 	return vc;
 }
 

--- a/platform/iphone/library_entry.mm
+++ b/platform/iphone/library_entry.mm
@@ -113,17 +113,30 @@ UIViewController *godot_library_make_view_controller(void) {
 
 	[AppDelegate setViewController:vc];
 
-	// In the standalone Godot iOS flow, OSIPhone::on_focus_in() (triggered
-	// by the Godot AppDelegate's applicationDidBecomeActive) is what starts
-	// the CADisplayLink and drives drawView → setupView → Main::start().
-	// Library-mode hosts (e.g. a React Native shell) have their own app
-	// delegate and never forward applicationDidBecomeActive here, so we
-	// kick off rendering manually. The host is still responsible for
-	// forwarding subsequent focus-in/out events; for this prototype a
-	// one-shot kick at mount time is enough.
-	OSIPhone::get_singleton()->on_focus_in();
+	// Rendering does NOT start here. Hosts call godot_library_focus_in()
+	// after the VC becomes visible (root-VC swap completes, view is added
+	// to a window). This matches the on_focus_in / on_focus_out pattern
+	// Godot's standalone AppDelegate uses via applicationDidBecomeActive /
+	// applicationWillResignActive, but gives the library-mode host control
+	// over when the CADisplayLink spins.
 
 	return vc;
+}
+
+void godot_library_focus_in(void) {
+	if (!g_started) {
+		return;
+	}
+	NSLog(@"[godot-lib] focus_in — resuming rendering/audio");
+	OSIPhone::get_singleton()->on_focus_in();
+}
+
+void godot_library_focus_out(void) {
+	if (!g_started) {
+		return;
+	}
+	NSLog(@"[godot-lib] focus_out — pausing rendering/audio");
+	OSIPhone::get_singleton()->on_focus_out();
 }
 
 void godot_library_stop(void) {

--- a/platform/iphone/library_entry.mm
+++ b/platform/iphone/library_entry.mm
@@ -72,6 +72,7 @@ static void build_argv_from_array(NSArray<NSString *> *cmdline) {
 }
 
 int godot_library_start(NSArray<NSString *> *cmdline, NSString *dataDir) {
+	NSLog(@"[godot-lib] godot_library_start called, g_started=%d", g_started);
 	if (g_started) {
 		return 0;
 	}
@@ -79,17 +80,28 @@ int godot_library_start(NSArray<NSString *> *cmdline, NSString *dataDir) {
 		return -1;
 	}
 
+	// Flip the guard BEFORE calling into iphone_main. iphone_main /
+	// Main::setup / register_core_types mutates process-wide singletons
+	// (StringName::configured, IP::singleton, InputMap::singleton, ...);
+	// a crash or exception thrown anywhere inside would leave the engine
+	// half-initialized. If the host retries enter() we must NOT reach
+	// register_core_types again — the ERR_FAIL_COND messages are harmless
+	// but a second IP::create / InputMap() hits an abort in some
+	// configurations.
+	g_started = YES;
 	build_argv_from_array(cmdline);
 
 	int err = iphone_main(g_argc, g_argv, String::utf8([dataDir UTF8String]));
+	NSLog(@"[godot-lib] iphone_main returned err=%d", err);
 	if (err != 0) {
 		return err;
 	}
 
 	bool keep_screen_on = bool(GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true));
+	NSLog(@"[godot-lib] keep_screen_on=%d", keep_screen_on);
 	OSIPhone::get_singleton()->set_keep_screen_on(keep_screen_on);
 
-	g_started = YES;
+	NSLog(@"[godot-lib] godot_library_start done");
 	return 0;
 }
 

--- a/platform/iphone/main.m
+++ b/platform/iphone/main.m
@@ -36,6 +36,7 @@
 int gargc;
 char **gargv;
 
+#ifndef IOS_LIBRARY_MODE
 int main(int argc, char *argv[]) {
 	printf("*********** main.m\n");
 	gargc = argc;
@@ -49,3 +50,4 @@ int main(int argc, char *argv[]) {
 	printf("main done\n");
 	return 0;
 }
+#endif // IOS_LIBRARY_MODE

--- a/platform/iphone/os_iphone.mm
+++ b/platform/iphone/os_iphone.mm
@@ -34,6 +34,7 @@
 
 #include "drivers/gles2/rasterizer_gles2.h"
 #include "drivers/gles3/rasterizer_gles3.h"
+#include "host_input_queue.h"
 #include "servers/visual/visual_server_raster.h"
 #include "servers/visual/visual_server_wrap_mt.h"
 
@@ -68,6 +69,29 @@ static init_callback *ios_init_callbacks = NULL;
 static int ios_init_callbacks_count = 0;
 static int ios_init_callbacks_capacity = 0;
 HashMap<String, void *> OSIPhone::dynamic_symbol_lookup_table;
+
+// UIKit/AVFoundation APIs are main-thread-only. Several OSIPhone methods are
+// reachable from GDScript (and thus from the engine worker thread that drives
+// Main::iteration in library mode). Hop to the UIApplication main queue when
+// we're not already there. dispatch_async fits the fire-and-forget calls;
+// dispatch_sync (with a guard) is used by the few methods that have to return
+// a value read from UIKit. Calls made from the standalone-app path (where
+// OSIPhone is created on main) skip the hop entirely thanks to the guard.
+static inline void osiphone_run_on_main_async(dispatch_block_t block) {
+	if ([NSThread isMainThread]) {
+		block();
+	} else {
+		dispatch_async(dispatch_get_main_queue(), block);
+	}
+}
+
+static inline void osiphone_run_on_main_sync(dispatch_block_t block) {
+	if ([NSThread isMainThread]) {
+		block();
+	} else {
+		dispatch_sync(dispatch_get_main_queue(), block);
+	}
+}
 
 int OSIPhone::get_video_driver_count() const {
 	return 2;
@@ -207,6 +231,11 @@ bool OSIPhone::iterate() {
 	if (!main_loop) {
 		return true;
 	}
+
+	// Drain UIKit-thread input (touches, keyboard) into the engine's
+	// InputDefault before stepping the scene. The producers push POD events
+	// into HostInputQueue from main; this is the consumer side.
+	HostInputQueue::get().drain();
 
 	return Main::iteration();
 };
@@ -355,9 +384,14 @@ void OSIPhone::set_window_title(const String &p_title) {
 }
 
 void OSIPhone::alert(const String &p_alert, const String &p_title) {
-	const CharString utf8_alert = p_alert.utf8();
-	const CharString utf8_title = p_title.utf8();
-	iOS::alert(utf8_alert.get_data(), utf8_title.get_data());
+	// Promote to NSString so the strings outlive this stack frame — the
+	// dispatch_async below may run after we've returned, and CharString's
+	// backing buffer would be gone.
+	NSString *ns_alert = [[NSString alloc] initWithUTF8String:p_alert.utf8().get_data()];
+	NSString *ns_title = [[NSString alloc] initWithUTF8String:p_title.utf8().get_data()];
+	osiphone_run_on_main_async(^{
+		iOS::alert([ns_alert UTF8String], [ns_title UTF8String]);
+	});
 }
 
 // MARK: Dynamic Libraries
@@ -450,16 +484,23 @@ void OSIPhone::show_virtual_keyboard(const String &p_existing_text, const Rect2 
 			keyboard_type = UIKeyboardTypeDefault;
 	 }
 
-	[AppDelegate.viewController.keyboardView
-			becomeFirstResponderWithString:existingString
-								 multiline:p_multiline
-							   cursorStart:p_cursor_start
-								 cursorEnd:p_cursor_end
-							  keyboardType:keyboard_type];
+	BOOL multiline = p_multiline;
+	int cursor_start = p_cursor_start;
+	int cursor_end = p_cursor_end;
+	osiphone_run_on_main_async(^{
+		[AppDelegate.viewController.keyboardView
+				becomeFirstResponderWithString:existingString
+									 multiline:multiline
+								   cursorStart:cursor_start
+									 cursorEnd:cursor_end
+								  keyboardType:keyboard_type];
+	});
 };
 
 void OSIPhone::hide_virtual_keyboard() {
-	[AppDelegate.viewController.keyboardView resignFirstResponder];
+	osiphone_run_on_main_async(^{
+		[AppDelegate.viewController.keyboardView resignFirstResponder];
+	});
 }
 
 void OSIPhone::set_virtual_keyboard_height(int p_height) {
@@ -483,20 +524,28 @@ Error OSIPhone::shell_open(String p_uri) {
 	NSString *urlPath = [[NSString alloc] initWithUTF8String:p_uri.utf8().get_data()];
 	NSURL *url = [NSURL URLWithString:urlPath];
 
-	if (![[UIApplication sharedApplication] canOpenURL:url]) {
+	__block BOOL canOpen = NO;
+	osiphone_run_on_main_sync(^{
+		canOpen = [[UIApplication sharedApplication] canOpenURL:url];
+	});
+	if (!canOpen) {
 		return ERR_CANT_OPEN;
 	}
 
 	printf("opening url %s\n", p_uri.utf8().get_data());
 
-	[[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+	osiphone_run_on_main_async(^{
+		[[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+	});
 
 	return OK;
 }
 
 void OSIPhone::set_keep_screen_on(bool p_enabled) {
 	OS::set_keep_screen_on(p_enabled);
-	[UIApplication sharedApplication].idleTimerDisabled = p_enabled;
+	osiphone_run_on_main_async(^{
+		[UIApplication sharedApplication].idleTimerDisabled = p_enabled;
+	});
 };
 
 int _get_system_orientation() {
@@ -686,12 +735,17 @@ int OSIPhone::get_screen_dpi(int p_screen) const {
 
 Rect2 OSIPhone::get_window_safe_area() const {
 	if (@available(iOS 11, *)) {
-		UIEdgeInsets insets = UIEdgeInsetsZero;
-		UIView *view = AppDelegate.viewController.godotView;
-
-		if ([view respondsToSelector:@selector(safeAreaInsets)]) {
-			insets = [view safeAreaInsets];
-		}
+		__block UIEdgeInsets insets = UIEdgeInsetsZero;
+		// safeAreaInsets is a UIView API — sync hop, since this is a value
+		// query. Safe at steady state; only risky if called while main is
+		// blocked waiting on the engine thread, which doesn't happen in
+		// post-boot lifetime.
+		osiphone_run_on_main_sync(^{
+			UIView *view = AppDelegate.viewController.godotView;
+			if ([view respondsToSelector:@selector(safeAreaInsets)]) {
+				insets = [view safeAreaInsets];
+			}
+		});
 
 		float scale = [UIScreen mainScreen].nativeScale;
 		Size2i insets_position = Size2i(insets.left, insets.top) * scale;
@@ -751,38 +805,51 @@ Error OSIPhone::native_video_play(String p_path, float p_volume, String p_audio_
 	NSString *audioTrack = [NSString stringWithUTF8String:p_audio_track.utf8()];
 	NSString *subtitleTrack = [NSString stringWithUTF8String:p_subtitle_track.utf8()];
 
-	if (![AppDelegate.viewController playVideoAtPath:filePath
-											  volume:p_volume
-											   audio:audioTrack
-											subtitle:subtitleTrack]) {
-		return OK;
-	}
-
-	return FAILED;
+	__block BOOL videoStarted = NO;
+	float volume = p_volume;
+	osiphone_run_on_main_sync(^{
+		videoStarted = ![AppDelegate.viewController playVideoAtPath:filePath
+															 volume:volume
+															  audio:audioTrack
+														   subtitle:subtitleTrack];
+	});
+	return videoStarted ? OK : FAILED;
 }
 
 bool OSIPhone::native_video_is_playing() const {
-	return [AppDelegate.viewController.videoView isVideoPlaying];
+	__block BOOL playing = NO;
+	osiphone_run_on_main_sync(^{
+		playing = [AppDelegate.viewController.videoView isVideoPlaying];
+	});
+	return playing;
 }
 
 void OSIPhone::native_video_pause() {
-	if (native_video_is_playing()) {
-		[AppDelegate.viewController.videoView pauseVideo];
-	}
+	osiphone_run_on_main_async(^{
+		if ([AppDelegate.viewController.videoView isVideoPlaying]) {
+			[AppDelegate.viewController.videoView pauseVideo];
+		}
+	});
 }
 
 void OSIPhone::native_video_unpause() {
-	[AppDelegate.viewController.videoView unpauseVideo];
+	osiphone_run_on_main_async(^{
+		[AppDelegate.viewController.videoView unpauseVideo];
+	});
 }
 
 void OSIPhone::native_video_focus_out() {
-	[AppDelegate.viewController.videoView unfocusVideo];
+	osiphone_run_on_main_async(^{
+		[AppDelegate.viewController.videoView unfocusVideo];
+	});
 }
 
 void OSIPhone::native_video_stop() {
-	if (native_video_is_playing()) {
-		[AppDelegate.viewController.videoView stopVideo];
-	}
+	osiphone_run_on_main_async(^{
+		if ([AppDelegate.viewController.videoView isVideoPlaying]) {
+			[AppDelegate.viewController.videoView stopVideo];
+		}
+	});
 }
 
 void OSIPhone::vibrate_handheld(int p_duration_ms) {

--- a/platform/iphone/view_controller.mm
+++ b/platform/iphone/view_controller.mm
@@ -112,6 +112,16 @@
 		blue:0.79
 		alpha:1.0
 	];
+	// Paint the GL view the same indigo so a landscape<->portrait rotation's
+	// uncovered strip shows purple, not black. app_delegate.mm does this for the
+	// standalone app; library hosts (futuramath's Expo app) don't run that
+	// delegate, so paint it here too.
+	self.godotView.backgroundColor = [UIColor 
+		colorWithRed:0.42
+		green:0.35
+		blue:0.79
+		alpha:1.0
+	];
 }
 
 - (void)observeKeyboard {


### PR DESCRIPTION
Wraps our Godot 3.3 fork (3.3 + 374 commits) to run as a **static library inside a React Native iOS app, on its own thread**, with the host app owning UIKit. `react` is 17 commits over `master` (the embedding seam).

**Doc/review PR — `react` stays the working branch; not merging yet.** Built locally only (no CI, iOS-only).

## Decisions
Godot is a *guest*, not the app: the host owns the UIWindow / root view controller; Godot ticks on a background pthread and renders into a view the host swaps in. Stay on 3.3 (the whole game is GDScript/3.3) — the fork only adds an embedding seam, no engine upgrade.

## Separate-thread / library architecture
`platform/iphone/library_entry.{h,mm}`, `core/os/thread.h`
- `godot_library_start()` spawns a dedicated engine pthread that runs `Main::setup` and returns immediately, so the host keeps its UI responsive (splash / spinner) while the engine boots. Readiness is published two ways — an atomic poll flag and a ready notification. Re-entry safe.
- `core/os/thread.h` `make_main_thread()` reassigns `main_thread_id` to the worker thread before `Main::setup`, so engine-wide `is_main_thread` checks hold when the engine is driven off the platform main thread.
- From `focus_in` on, engine-touching calls and the `CADisplayLink` are marshalled onto the engine thread's `CFRunLoop` (`CFRunLoopPerformBlock` + `WakeUp`), so `drawView` / `Main::iteration` run off-main. `focus_in/out` are exposed to the host; auto-focus on view-controller creation is dropped.
- vs stock: stock iOS Godot owns the process main thread via `UIApplicationMain`; here the host owns UIKit and Godot is a background tick.

## Rendering
`platform/iphone/godot_view.mm`, `view_controller.mm`
- GLES2 into a `CAEAGLLayer`; `drawView` driven by the engine-thread `CADisplayLink`.
- Off-screen, render-free boot: the engine can boot with the render loop disabled and idle cheaply behind the host's boot UI, then re-enable rendering right before the host swaps it on-screen — avoids GLES cost and a pre-present flash.
- Constraint: rotating the GLES context while rendering off-screen segfaults the rasterizer, so the host rotates **before** swapping Godot in; Godot's orientation is fixed once it's the root.

## Audio
`platform/iphone/os_iphone.mm` (stock `AudioDriverCoreAudio`)
- In library mode Godot does **not** configure `AVAudioSession` — the host owns it (category `.playback`, 44100 Hz, active) and must set it before `godot_library_start()`, else CoreAudio `AudioOutputUnitStart` fails `-50` on a 44100/48000 sample-rate mismatch. A focus-out→in cycle on present starts the unit once an output route exists.

## Host messaging + input seam
`platform/iphone/ios.{h,mm}`, new `platform/iphone/host_input_queue.{h,mm}`, `os_iphone.mm`
- Outbound (GDScript → host, `NSNotification`): `iOS.host_ready(reason)` and `iOS.goto_host(reason)`. No-op when no host observes.
- Inbound (host → GDScript): the host posts a command notification; re-emitted as the `host_command(name)` GDScript signal via `call_deferred` (engine-thread safe).
- `host_input_queue` (this PR): a single-producer / single-consumer ring that ferries UIKit-thread touch / keyboard input into the engine worker; drained in `OSIPhone::iterate()` before `Main::iteration` (producers in `godot_view` / `keyboard_input_view` / `view_controller`).
- UIKit / AVFoundation-touching `OSIPhone` methods (alert, virtual keyboard, …) now hop to the main queue, since GDScript runs on the worker thread in library mode. OS-level integrations (URL open, payments, push, deep links) route through these stock, now-thread-safe paths plus the `iOS` singleton; plugin init hooks remain weak stubs.

## Library-mode build
`platform/iphone/detect.py`, `SCsub`
- `ios_library=yes` → `IOS_LIBRARY_MODE`: exports `godot_library_start`, omits stock `_main` / `UIApplicationMain`. Output `libgodot.iphone.*.a`, consumed by the host build as a prebuilt archive alongside the standard Godot iOS export.

## Status (honest)
Local builds only, no CI, iOS-only (Android still stock 3.3), not yet reviewed. Reproducible via the host project's build tooling.
